### PR TITLE
changing construct.link to construct_link so function works

### DIFF
--- a/R/interact_nodes.R
+++ b/R/interact_nodes.R
@@ -19,15 +19,15 @@ get.nodes <- function(id = NULL, # make this loopable?
                       files = FALSE,
                       children = FALSE){ # add a recurse argument?b
   if (is.null(id)){
-    call <- httr::GET(construct.link('nodes'))
+    call <- httr::GET(construct_link('nodes'))
   } else if (id == 'me'){
     if(Sys.getenv('OSF_PAT') == '') stop('Requires login')
 
     # Does this work? Should test
-    call <- httr::GET(construct.link('nodes'),
+    call <- httr::GET(construct_link('nodes'),
                       httr::add_headers(Authorization = sprintf('Bearer %s', login())))
   } else {
-    call <- httr::GET(construct.link(paste('nodes', id, sep = '/')))
+    call <- httr::GET(construct_link(paste('nodes', id, sep = '/')))
   }
 
   res <- rjson::fromJSON(httr::content(call, 'text'))

--- a/R/interact_users.R
+++ b/R/interact_users.R
@@ -8,7 +8,7 @@
 
 get.users <- function(id = NULL, nodes = FALSE){
   if (Sys.getenv("OSF_PAT") == "" & is.null(id)){
-    raw <- httr::GET(construct.link("users"))
+    raw <- httr::GET(construct_link("users"))
 
     result <- rjson::fromJSON(httr::content(raw, 'text'))
   } else if (id == "me"){
@@ -17,10 +17,10 @@ get.users <- function(id = NULL, nodes = FALSE){
       warning("Please login first using the login() function")}
 
     if(nodes == TRUE){
-      raw <- httr::GET(construct.link("users/me/nodes"),
+      raw <- httr::GET(construct_link("users/me/nodes"),
                        httr::add_headers(Authorization = sprintf("Bearer %s", login())))
     } else {
-      raw <- httr::GET(construct.link("users/me"),
+      raw <- httr::GET(construct_link("users/me"),
                        httr::add_headers(Authorization = sprintf("Bearer %s", login())))
     }
 


### PR DESCRIPTION
the get.nodes function wasn't running, as it couldn't find the 'construct.link' function. Elsewhere in the repo it's defined as construct_link, so I changed construct.link to construct_link so get.nodes would run