### PR TITLE
update download_file to fix error

### DIFF
--- a/R/files.R
+++ b/R/files.R
@@ -288,12 +288,7 @@ download_file <- function(id, path = NULL, private = FALSE) {
   res <- process_json(call)
 
   # Find the filename as on the OSF
-  if (is.null(file)) {
-    txt <- res$data$attributes$name
-    start <- utils::tail(gregexpr("/", txt)[[1]], 1)
-    end <-  nchar(txt)
-    file <- substr(txt, start + 1, end)
-  }
+  file <- res$data$attributes$name
 
   message(paste0("Saving to filename: ", file))
 


### PR DESCRIPTION
is.null(file) returns FALSE, so if() statement wasn't getting run and variable file wasn't getting a file name, resulting in "Error in paste0("Saving to filename: ", file) : cannot coerce type 'closure' to vector of type 'character'" when attempting to use download function. Changed to get file name directly from API call results