### PR TITLE
update download_file bug

### DIFF
--- a/R/files.R
+++ b/R/files.R
@@ -288,7 +288,7 @@ download_file <- function(id, path = NULL, private = FALSE) {
   res <- process_json(call)
 
   # Find the filename as on the OSF
-  if (is.null(file)) {
+  if (is.null(path)) {
     txt <- res$data$attributes$name
     start <- utils::tail(gregexpr("/", txt)[[1]], 1)
     end <-  nchar(txt)


### PR DESCRIPTION
Function was throwing "Error in paste0("Saving to filename: ", file) : cannot coerce type 'closure' to vector of type 'character' error b/c function sets 'path' to null as default, but if (is.null()) still calls 'file' rather than 'path' and file isn't set to null, so if () wasn't running. Changed file to path in if (is.null()) to fix bug