### PR TITLE
Add encoding to httr::content() calls.

### DIFF
--- a/R/nodes.R
+++ b/R/nodes.R
@@ -63,7 +63,7 @@ get_nodes <- function(
   while (!is.null(res$links$`next`)) {
     whilst <- rjson::fromJSON(
       httr::content(
-        httr::GET(res$links$`next`, config), "text"))
+        httr::GET(res$links$`next`, config), "text", encoding = "UTF-8"))
     res$data <- c(res$data, whilst$data)
     res$links$`next` <- whilst$links$`next`
     message(paste0(res$links$`next`))

--- a/R/search.R
+++ b/R/search.R
@@ -53,7 +53,7 @@ search_nodes <- function(
   while (!is.null(res$links$`next`)) {
     whilst <- rjson::fromJSON(
       httr::content(
-        httr::GET(res$links$`next`), "text"))
+        httr::GET(res$links$`next`), "text", encoding = "UTF-8"))
     res$data <- c(res$data, whilst$data)
     res$links$`next` <- whilst$links$`next`
     message(paste0(res$links$`next`))

--- a/R/search.R
+++ b/R/search.R
@@ -134,7 +134,7 @@ search_users <- function(full_name = NULL, family_name = NULL) {
   while (!is.null(res$links$`next`)) {
     whilst <- rjson::fromJSON(
       httr::content(
-        httr::GET(res$links$`next`), "text"))
+        httr::GET(res$links$`next`), "text", encoding = "UTF-8"))
     res$data <- c(res$data, whilst$data)
     res$links$`next` <- whilst$links$`next`
     message(paste0(res$links$`next`))

--- a/R/users.R
+++ b/R/users.R
@@ -34,7 +34,7 @@ get_users <- function(id = 'me', nodes = FALSE) {
   while (!is.null(res$links$`next`)){
     whilst <- rjson::fromJSON(
       httr::content(
-        httr::GET(res$links$`next`), "text"))
+        httr::GET(res$links$`next`), "text"), encoding = "UTF-8")
     res$data <- c(res$data, whilst$data)
     res$links$`next` <- whilst$links$`next`
     message(paste0(res$links$`next`))

--- a/R/users.R
+++ b/R/users.R
@@ -34,7 +34,7 @@ get_users <- function(id = 'me', nodes = FALSE) {
   while (!is.null(res$links$`next`)){
     whilst <- rjson::fromJSON(
       httr::content(
-        httr::GET(res$links$`next`), "text"), encoding = "UTF-8")
+        httr::GET(res$links$`next`), "text", encoding = "UTF-8"))
     res$data <- c(res$data, whilst$data)
     res$links$`next` <- whilst$links$`next`
     message(paste0(res$links$`next`))

--- a/R/utils.R
+++ b/R/utils.R
@@ -83,7 +83,7 @@ process_category <- function(category = '') {
 #' @return Parsed JSON object in the form of an R object.
 
 process_json <- function(x) {
-  rjson::fromJSON(httr::content(x, 'text'))
+  rjson::fromJSON(httr::content(x, 'text', encoding = "UTF-8"))
 }
 
 #' Identify type of endpoint for id


### PR DESCRIPTION
Hi Chris,

I've updated the httr::content() calls within process_json() to include an explicit encoding to UTF-8. This should remove the "No encoding supplied: defaulting to UTF-8." message coming from httr::content(). I've also added the explicit UTF-8 encoding to httr:content() calls in get_users(), search_nodes(), search_users(), and get_nodes().

Thanks for all of your work on this package!