### PR TITLE
Fix for file not found warning in `login()` 

### DIFF
--- a/R/account.R
+++ b/R/account.R
@@ -55,7 +55,7 @@ login <- function(pat = NULL) {
       Sys.setenv(OSF_PAT = input)
 
       # Write to file in a normalized manner across UNIX and Windows
-      connect <- file(normalizePath('~/.osf_config'))
+      connect <- file(normalizePath('~/.osf_config', mustWork = FALSE))
       writeLines(input, connect)
       close(connect)
   }


### PR DESCRIPTION
I ran into the following warning when trying to run login() on my Windows 10 machine.

``` r
library(osfr)
login()
#> Visit https://osf.io/settings/tokens/
#>                   and create a Personal access token:
#> Warning in normalizePath(path.expand(path), winslash, mustWork):
#> path[1]="C:/Users/brian/Documents/.osf_config": The system cannot find the
#> file specified
```

The `login()` function itself works fine and creates the `.osf_config` file as it should. From discussions with other users running osfr on Mac, it doesn't look like this warning appears for them. It may just be a Windows problem, but it looks like an easy fix is to use the mustWork argument in `normalizePath()` and set it to FALSE. According to the documentation for `normalizePath()`, this should suppress the warning created when `normalizePath()` can't find the `.osf_config` file. 