### PR TITLE
Fix for parentheses error in logged_in().

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -1,7 +1,7 @@
 #' Identify whether logged in
 
 logged_in <- function () {
-  if (Sys.getenv('OSF_PAT' == '')) {
+  if (Sys.getenv('OSF_PAT') == '') {
     return(FALSE)
   }
   return(TRUE)


### PR DESCRIPTION
Noticed this while working on some changes to `download_files()`. It should now return FALSE if there is no PAT and TRUE if there is a PAT.